### PR TITLE
feat: Implement IP threat scoring system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ percent-encoding = "2.3.1"
 tempfile = "3.20.0"
 sha2 = "0.10"
 reqwest = { version = "0.12", features = ["blocking", "json"] }
+dashmap = "6.1.0"
 
 [dev-dependencies]
 tower-test = "0.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::RwLock;
@@ -75,6 +76,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let state = AppState { 
         maxmind_reader: Arc::new(RwLock::new(reader)),
         asn_reader: Arc::new(RwLock::new(asn_reader)),
+        lookup_cache: Arc::new(RwLock::new(HashMap::new())),
     };
 
     // Create router

--- a/src/models/location.rs
+++ b/src/models/location.rs
@@ -26,30 +26,30 @@ impl From<geoip2::City<'_>> for GeoInfo {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct GeoInfo {
     pub city: Option<City>,
     pub country: Option<Country>,
     pub location: Option<Location>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct City {
     pub names: Option<std::collections::HashMap<String, String>>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Country {
     pub names: Option<std::collections::HashMap<String, String>>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Location {
     pub latitude: Option<f64>,
     pub longitude: Option<f64>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct AsnInfo {
     pub autonomous_system_number: Option<u32>,
     pub autonomous_system_organization: Option<String>,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,1 +1,2 @@
 pub mod location;
+pub mod threat_score;

--- a/src/models/threat_score.rs
+++ b/src/models/threat_score.rs
@@ -1,0 +1,142 @@
+use serde::Serialize;
+use std::net::IpAddr;
+
+/// Represents different types of threats that can contribute to the overall threat score
+#[derive(Debug, Clone, Copy, Serialize)]
+pub enum ThreatType {
+    VpnOrDatacenter,
+    Proxy,
+    TorExitNode,
+    // Add more threat types here as needed
+}
+
+/// Represents a single threat finding with its type and weight
+#[derive(Debug, Clone, Serialize)]
+pub struct ThreatFinding {
+    pub threat_type: ThreatType,
+    pub description: String,
+    pub weight: f32,  // Weight between 0.0 and 1.0 indicating severity
+}
+
+/// Configuration for threat scoring
+#[derive(Debug, Clone)]
+pub struct ThreatScoringConfig {
+    pub vpn_weight: f32,
+    pub proxy_weight: f32,
+    pub tor_weight: f32,
+    // Add more weights for future threat types
+}
+
+impl Default for ThreatScoringConfig {
+    fn default() -> Self {
+        Self {
+            vpn_weight: 0.6,    // High weight for VPN/Data center
+            proxy_weight: 0.8,  // Higher weight for proxies
+            tor_weight: 0.9,    // Very high weight for Tor exit nodes
+        }
+    }
+}
+
+/// Calculates a threat score based on various threat findings
+#[derive(Debug, Clone, Serialize)]
+pub struct ThreatScore {
+    pub score: u8,  // 0-100, higher is more suspicious
+    pub findings: Vec<ThreatFinding>,
+    pub ip: IpAddr,
+}
+
+impl ThreatScore {
+    /// Creates a new threat score for the given IP address
+    pub fn new(ip: IpAddr) -> Self {
+        Self {
+            score: 0,
+            findings: Vec::new(),
+            ip,
+        }
+    }
+
+    /// Adds a threat finding and updates the score
+    /*pub fn add_finding(&mut self, finding: ThreatFinding) {
+        self.findings.push(finding);
+        self.calculate_score();
+    }*/
+
+    /// Adds multiple threat findings and updates the score
+    pub fn add_findings(&mut self, findings: impl IntoIterator<Item = ThreatFinding>) {
+        self.findings.extend(findings);
+        self.calculate_score();
+    }
+
+    /// Calculates the overall threat score based on all findings
+    fn calculate_score(&mut self) {
+        let config = ThreatScoringConfig::default();
+        let mut weighted_sum = 0.0;
+        let mut total_weight = 0.0;
+
+        for finding in &self.findings {
+            let weight = match finding.threat_type {
+                ThreatType::VpnOrDatacenter => config.vpn_weight,
+                ThreatType::Proxy => config.proxy_weight,
+                ThreatType::TorExitNode => config.tor_weight,
+                // Add new threat types here
+            };
+            
+            weighted_sum += finding.weight * weight;
+            total_weight += weight;
+        }
+
+        // Normalize the score to 0-100 range
+        let normalized_score = if total_weight > 0.0 {
+            (weighted_sum / total_weight * 100.0) as u8
+        } else {
+            0
+        };
+
+        self.score = normalized_score.min(100); // Cap at 100
+    }
+
+    /// Creates a threat score from common IP information
+    pub fn from_ip_info(
+        ip: IpAddr,
+        is_vpn: bool,
+        is_proxy: bool,
+        proxy_type: Option<&'static str>,
+        is_tor: bool,
+    ) -> Self {
+        let mut score = Self::new(ip);
+        let mut findings = Vec::new();
+
+        if is_vpn {
+            findings.push(ThreatFinding {
+                threat_type: ThreatType::VpnOrDatacenter,
+                description: "IP is associated with a VPN or data center".to_string(),
+                weight: 1.0,  // Full weight for binary detection
+            });
+        }
+
+        if is_proxy {
+            let proxy_desc = if let Some(proxy_type) = proxy_type {
+                format!("IP is a known {} proxy", proxy_type)
+            } else {
+                "IP is a known proxy".to_string()
+            };
+            
+            findings.push(ThreatFinding {
+                threat_type: ThreatType::Proxy,
+                description: proxy_desc,
+                weight: 1.0,  // Full weight for binary detection
+            });
+        }
+
+        if is_tor {
+            findings.push(ThreatFinding {
+                threat_type: ThreatType::TorExitNode,
+                description: "IP is a known Tor exit node".to_string(),
+                weight: 1.0,  // Full weight for binary detection
+            });
+        }
+
+        score.add_findings(findings);
+        score
+    }
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -36,6 +36,18 @@ pub fn create_router(state: AppState) -> Router {
             }),
         )
 
+         // Get threat score for a specific IP
+         .route(
+            "/api/threat_score/{ip}",
+            get(handlers::get_threat_score),
+        )
+
+        // Get threat score for self IP
+        .route(
+            "/api/threat_score/self",
+            get(handlers::get_self_threat_score),
+        )
+
         // Check if IP is a VPN or datacenter
         // Takes in a network range (CIDR) (also works if a regular ip is passed)
         .route(

--- a/src/services/lookup_service.rs
+++ b/src/services/lookup_service.rs
@@ -1,0 +1,95 @@
+// lookup_service.rs
+use std::net::IpAddr;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use crate::models::location::{GeoInfo, AsnInfo};
+use crate::models::threat_score::ThreatScore;
+use crate::services::vpn_detection::VpnDetector;
+use crate::services::proxy_detection::ProxyDetector;
+use crate::services::tor_detection::TorDetector;
+use crate::handlers::LookupResponse;
+use crate::errors::AppError;
+use std::collections::HashMap;
+
+pub struct LookupService {
+    maxmind_reader: Arc<RwLock<maxminddb::Reader<Vec<u8>>>>,
+    asn_reader: Arc<RwLock<maxminddb::Reader<Vec<u8>>>>,
+    lookup_cache: Arc<RwLock<HashMap<IpAddr, LookupResponse>>>,
+}
+
+impl LookupService {
+    pub fn new(
+        maxmind_reader: Arc<RwLock<maxminddb::Reader<Vec<u8>>>>,
+        asn_reader: Arc<RwLock<maxminddb::Reader<Vec<u8>>>>,
+        lookup_cache: Arc<RwLock<HashMap<IpAddr, LookupResponse>>>,
+    ) -> Self {
+        Self {
+            maxmind_reader,
+            asn_reader,
+            lookup_cache,
+        }
+    }
+
+    pub async fn lookup_ip(&self, ip_addr: IpAddr) -> Result<LookupResponse, AppError> {
+        if let Some(cached) = self.lookup_cache.read().await.get(&ip_addr) {
+            return Ok(cached.clone());
+        }
+
+        let reader = self.maxmind_reader.read().await;
+        let asn_reader = self.asn_reader.read().await;
+        let vpn_detector = VpnDetector::get();
+        let proxy_detector = ProxyDetector::get();
+        let tor_detector = TorDetector::get();
+
+        let (geo_result, asn_result, vpn_result, proxy_result, tor_result) = tokio::join!(
+            async { reader.lookup(ip_addr) },
+            async { asn_reader.lookup(ip_addr) },
+            async { vpn_detector.is_vpn_or_datacenter(ip_addr) },
+            async { proxy_detector.check_proxy(ip_addr) },
+            async { tor_detector.is_tor_exit_node(ip_addr) },
+        );
+
+        let city: Option<maxminddb::geoip2::City<'_>> = geo_result?;
+        let asn: Option<maxminddb::geoip2::Asn<'_>> = asn_result?;
+        let geo_info = GeoInfo::from(city.ok_or_else(|| 
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound, 
+                "No geo data found for this IP address"
+            )
+        )?);
+        
+        let asn_info = asn.as_ref().map(AsnInfo::from);
+        let is_vpn = vpn_result;
+        let proxy_type = proxy_result;
+        let is_proxy = proxy_type.is_some();
+        let is_tor = tor_result;
+
+        let threat_score = ThreatScore::from_ip_info(
+            ip_addr,
+            is_vpn,
+            is_proxy,
+            proxy_type,
+            is_tor,
+        );
+
+        let threat_details = threat_score.findings
+            .iter()
+            .map(|f| f.description.clone())
+            .collect();
+
+        let response = LookupResponse {
+            ip: ip_addr.to_string(),
+            geo_info,
+            asn_info,
+            is_vpn_or_datacenter: is_vpn,
+            is_proxy,
+            proxy_type,
+            is_tor_exit_node: is_tor,
+            threat_score: threat_score.score,
+            threat_details,
+        };
+
+        self.lookup_cache.write().await.insert(ip_addr, response.clone());
+        Ok(response)
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -2,3 +2,4 @@ pub mod vpn_detection;
 pub mod proxy_detection;
 pub mod tor_detection;
 pub mod background_updater;
+pub mod lookup_service;


### PR DESCRIPTION
- Added ThreatScore model to calculate risk scores (0-100) based on IP reputation
- Integrated threat assessment into LookupService for all IP lookups
- Added dedicated endpoints for threat score lookup
- Included detailed threat findings with descriptions
- Implemented weighted scoring for different threat types:
  - VPN/Data center (weight: 0.6)
  - Proxy (weight: 0.8)
  - Tor exit node (weight: 0.9)
- Added response fields for threat score and details in lookup responses

The threat scoring system provides a quick way to assess the risk level of an IP address based on various reputation factors, with higher scores indicating higher risk.